### PR TITLE
Fix super + pointer actions

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -195,6 +195,8 @@ class CompizWindowsEffectExtension {
     }
 
     grabStart(window, op) {
+        op &= ~1024; // META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED
+        
         if (Meta.GrabOp.MOVING != op && (!this.prefs.RESIZE_EFFECT.get() || this.allowedResizeOp.indexOf(op) === -1)) {
             return;
         }


### PR DESCRIPTION
Mutter introduced the new flag META_GRAB_OP_WINDOW_FLAG_UNCONSTRAINED with a value of 1024 in 2d8fa26c. See that commit for more details. The flag is used to indicate wether a window is unconstrainted during a grab operation i. e. wether it can go under the top bar. As an example, this flag will be set, if the user starts an super + mouse action. That means the extension doesn't work on GNOME 44+ with super + pointer actions because it only checks whether the current grab op equals Meta.GrabOp.MOVING. To fix that remove the new flag from the grab op.